### PR TITLE
Update fs.md

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -175,7 +175,7 @@ added: v15.4.0
 The `'close'` event is emitted when the {FileHandle} has been closed and can no
 longer be used.
 
-#### `filehandle.appendFile(data[, options])`
+#### `filehandle.appendFile(data, [options])`
 
 <!-- YAML
 added: v10.0.0
@@ -417,7 +417,7 @@ Reads data from the file and stores that in the given buffer.
 If the file is not modified concurrently, the end-of-file is reached when the
 number of bytes read is zero.
 
-#### `filehandle.read(buffer[, options])`
+#### `filehandle.read(buffer, [options])`
 
 <!-- YAML
 added:
@@ -567,7 +567,7 @@ const { open } = require('node:fs/promises');
 })();
 ```
 
-#### `filehandle.readv(buffers[, position])`
+#### `filehandle.readv(buffers, [position])`
 
 <!-- YAML
 added:
@@ -660,7 +660,7 @@ added: v10.0.0
 Change the file system timestamps of the object referenced by the {FileHandle}
 then resolves the promise with no arguments upon success.
 
-#### `filehandle.write(buffer, offset[, length[, position]])`
+#### `filehandle.write(buffer, offset, [length, [position]])`
 
 <!-- YAML
 added: v10.0.0
@@ -698,7 +698,7 @@ On Linux, positional writes do not work when the file is opened in append mode.
 The kernel ignores the position argument and always appends the data to
 the end of the file.
 
-#### `filehandle.write(buffer[, options])`
+#### `filehandle.write(buffer, [options])`
 
 <!-- YAML
 added:
@@ -719,7 +719,7 @@ Similar to the above `filehandle.write` function, this version takes an
 optional `options` object. If no `options` object is specified, it will
 default with the above values.
 
-#### `filehandle.write(string[, position[, encoding]])`
+#### `filehandle.write(string, [position, [encoding]])`
 
 <!-- YAML
 added: v10.0.0
@@ -792,7 +792,7 @@ If one or more `filehandle.write()` calls are made on a file handle and then a
 current position till the end of the file. It doesn't always write from the
 beginning of the file.
 
-#### `filehandle.writev(buffers[, position])`
+#### `filehandle.writev(buffers, [position])`
 
 <!-- YAML
 added: v12.9.0
@@ -829,7 +829,7 @@ added: v20.4.0
 
 An alias for `filehandle.close()`.
 
-### `fsPromises.access(path[, mode])`
+### `fsPromises.access(path, [mode])`
 
 <!-- YAML
 added: v10.0.0
@@ -869,7 +869,7 @@ condition, since other processes may change the file's state between the two
 calls. Instead, user code should open/read/write the file directly and handle
 the error raised if the file is not accessible.
 
-### `fsPromises.appendFile(path, data[, options])`
+### `fsPromises.appendFile(path, data, [options])`
 
 <!-- YAML
 added: v10.0.0
@@ -919,7 +919,7 @@ added: v10.0.0
 
 Changes the ownership of a file.
 
-### `fsPromises.copyFile(src, dest[, mode])`
+### `fsPromises.copyFile(src, dest, [mode])`
 
 <!-- YAML
 added: v10.0.0
@@ -973,7 +973,7 @@ try {
 }
 ```
 
-### `fsPromises.cp(src, dest[, options])`
+### `fsPromises.cp(src, dest, [options])`
 
 <!-- YAML
 added: v16.7.0
@@ -1088,7 +1088,7 @@ added: v10.0.0
 Creates a new link from the `existingPath` to the `newPath`. See the POSIX
 link(2) documentation for more detail.
 
-### `fsPromises.lstat(path[, options])`
+### `fsPromises.lstat(path, [options])`
 
 <!-- YAML
 added: v10.0.0
@@ -1110,7 +1110,7 @@ Equivalent to [`fsPromises.stat()`][] unless `path` refers to a symbolic link,
 in which case the link itself is stat-ed, not the file that it refers to.
 Refer to the POSIX lstat(2) document for more detail.
 
-### `fsPromises.mkdir(path[, options])`
+### `fsPromises.mkdir(path, [options])`
 
 <!-- YAML
 added: v10.0.0
@@ -1159,7 +1159,7 @@ async function makeDirectory() {
 makeDirectory().catch(console.error);
 ```
 
-### `fsPromises.mkdtemp(prefix[, options])`
+### `fsPromises.mkdtemp(prefix, [options])`
 
 <!-- YAML
 added: v10.0.0
@@ -1207,7 +1207,7 @@ characters directly to the `prefix` string. For instance, given a directory
 `prefix` must end with a trailing platform-specific path separator
 (`require('node:path').sep`).
 
-### `fsPromises.open(path, flags[, mode])`
+### `fsPromises.open(path, flags, [mode])`
 
 <!-- YAML
 added: v10.0.0
@@ -1233,7 +1233,7 @@ by [Naming Files, Paths, and Namespaces][]. Under NTFS, if the filename contains
 a colon, Node.js will open a file system stream, as described by
 [this MSDN page][MSDN-Using-Streams].
 
-### `fsPromises.opendir(path[, options])`
+### `fsPromises.opendir(path, [options])`
 
 <!-- YAML
 added: v12.12.0
@@ -1286,7 +1286,7 @@ try {
 When using the async iterator, the {fs.Dir} object will be automatically
 closed after the iterator exits.
 
-### `fsPromises.readdir(path[, options])`
+### `fsPromises.readdir(path, [options])`
 
 <!-- YAML
 added: v10.0.0
@@ -1331,7 +1331,7 @@ try {
 }
 ```
 
-### `fsPromises.readFile(path[, options])`
+### `fsPromises.readFile(path, [options])`
 
 <!-- YAML
 added: v10.0.0
@@ -1418,7 +1418,7 @@ system requests but rather the internal buffering `fs.readFile` performs.
 
 Any specified {FileHandle} has to support reading.
 
-### `fsPromises.readlink(path[, options])`
+### `fsPromises.readlink(path, [options])`
 
 <!-- YAML
 added: v10.0.0
@@ -1438,7 +1438,7 @@ object with an `encoding` property specifying the character encoding to use for
 the link path returned. If the `encoding` is set to `'buffer'`, the link path
 returned will be passed as a {Buffer} object.
 
-### `fsPromises.realpath(path[, options])`
+### `fsPromises.realpath(path, [options])`
 
 <!-- YAML
 added: v10.0.0
@@ -1475,7 +1475,7 @@ added: v10.0.0
 
 Renames `oldPath` to `newPath`.
 
-### `fsPromises.rmdir(path[, options])`
+### `fsPromises.rmdir(path, [options])`
 
 <!-- YAML
 added: v10.0.0
@@ -1536,7 +1536,7 @@ error on POSIX.
 To get a behavior similar to the `rm -rf` Unix command, use
 [`fsPromises.rm()`][] with options `{ recursive: true, force: true }`.
 
-### `fsPromises.rm(path[, options])`
+### `fsPromises.rm(path, [options])`
 
 <!-- YAML
 added: v14.14.0
@@ -1560,7 +1560,7 @@ added: v14.14.0
 
 Removes files and directories (modeled on the standard POSIX `rm` utility).
 
-### `fsPromises.stat(path[, options])`
+### `fsPromises.stat(path, [options])`
 
 <!-- YAML
 added: v10.0.0
@@ -1578,7 +1578,7 @@ changes:
 * Returns: {Promise}  Fulfills with the {fs.Stats} object for the
   given `path`.
 
-### `fsPromises.statfs(path[, options])`
+### `fsPromises.statfs(path, [options])`
 
 <!-- YAML
 added:
@@ -1593,7 +1593,7 @@ added:
 * Returns: {Promise} Fulfills with the {fs.StatFs} object for the
   given `path`.
 
-### `fsPromises.symlink(target, path[, type])`
+### `fsPromises.symlink(target, path, [type])`
 
 <!-- YAML
 added: v10.0.0
@@ -1621,7 +1621,7 @@ path to be absolute. When using `'junction'`, the `target` argument will
 automatically be normalized to absolute path. Junction points on NTFS volumes
 can only point to directories.
 
-### `fsPromises.truncate(path[, len])`
+### `fsPromises.truncate(path, [len])`
 
 <!-- YAML
 added: v10.0.0
@@ -1668,7 +1668,7 @@ The `atime` and `mtime` arguments follow these rules:
 * If the value can not be converted to a number, or is `NaN`, `Infinity`, or
   `-Infinity`, an `Error` will be thrown.
 
-### `fsPromises.watch(filename[, options])`
+### `fsPromises.watch(filename, [options])`
 
 <!-- YAML
 added:
@@ -1720,7 +1720,7 @@ disappears in the directory.
 
 All the [caveats][] for `fs.watch()` also apply to `fsPromises.watch()`.
 
-### `fsPromises.writeFile(file, data[, options])`
+### `fsPromises.writeFile(file, data, [options])`
 
 <!-- YAML
 added: v10.0.0
@@ -1822,7 +1822,7 @@ system operations off the event loop thread. These operations are not
 synchronized or threadsafe. Care must be taken when performing multiple
 concurrent modifications on the same file or data corruption may occur.
 
-### `fs.access(path[, mode], callback)`
+### `fs.access(path, [mode], callback)`
 
 <!-- YAML
 added: v0.11.15
@@ -2012,7 +2012,7 @@ a file or directory. The `fs.access()` function, however, does not check the
 ACL and therefore may report that a path is accessible even if the ACL restricts
 the user from reading or writing to it.
 
-### `fs.appendFile(path, data[, options], callback)`
+### `fs.appendFile(path, data, [options], callback)`
 
 <!-- YAML
 added: v0.6.7
@@ -2226,7 +2226,7 @@ possible exception are given to the completion callback.
 
 See the POSIX chown(2) documentation for more detail.
 
-### `fs.close(fd[, callback])`
+### `fs.close(fd, [callback])`
 
 <!-- YAML
 added: v0.0.2
@@ -2263,7 +2263,7 @@ through any other `fs` operation may lead to undefined behavior.
 
 See the POSIX close(2) documentation for more detail.
 
-### `fs.copyFile(src, dest[, mode], callback)`
+### `fs.copyFile(src, dest, [mode], callback)`
 
 <!-- YAML
 added: v8.5.0
@@ -2319,7 +2319,7 @@ copyFile('source.txt', 'destination.txt', callback);
 copyFile('source.txt', 'destination.txt', constants.COPYFILE_EXCL, callback);
 ```
 
-### `fs.cp(src, dest[, options], callback)`
+### `fs.cp(src, dest, [options], callback)`
 
 <!-- YAML
 added: v16.7.0
@@ -2377,7 +2377,7 @@ including subdirectories and files.
 When copying a directory to another directory, globs are not supported and
 behavior is similar to `cp dir1/ dir2/`.
 
-### `fs.createReadStream(path[, options])`
+### `fs.createReadStream(path, [options])`
 
 <!-- YAML
 added: v0.1.31
@@ -2506,7 +2506,7 @@ createReadStream('sample.txt', { start: 90, end: 99 });
 
 If `options` is a string, then it specifies the encoding.
 
-### `fs.createWriteStream(path[, options])`
+### `fs.createWriteStream(path, [options])`
 
 <!-- YAML
 added: v0.1.31
@@ -2836,7 +2836,7 @@ operating system's synchronized I/O completion state. Refer to the POSIX
 fdatasync(2) documentation for details. No arguments other than a possible
 exception are given to the completion callback.
 
-### `fs.fstat(fd[, options], callback)`
+### `fs.fstat(fd, [options], callback)`
 
 <!-- YAML
 added: v0.1.95
@@ -2901,7 +2901,7 @@ device. The specific implementation is operating system and device specific.
 Refer to the POSIX fsync(2) documentation for more detail. No arguments other
 than a possible exception are given to the completion callback.
 
-### `fs.ftruncate(fd[, len], callback)`
+### `fs.ftruncate(fd, [len], callback)`
 
 <!-- YAML
 added: v0.8.6
@@ -3132,7 +3132,7 @@ Creates a new link from the `existingPath` to the `newPath`. See the POSIX
 link(2) documentation for more detail. No arguments other than a possible
 exception are given to the completion callback.
 
-### `fs.lstat(path[, options], callback)`
+### `fs.lstat(path, [options], callback)`
 
 <!-- YAML
 added: v0.1.30
@@ -3175,7 +3175,7 @@ link, then the link itself is stat-ed, not the file that it refers to.
 
 See the POSIX lstat(2) documentation for more details.
 
-### `fs.mkdir(path[, options], callback)`
+### `fs.mkdir(path, [options], callback)`
 
 <!-- YAML
 added: v0.1.8
@@ -3254,7 +3254,7 @@ mkdir('/', { recursive: true }, (err) => {
 
 See the POSIX mkdir(2) documentation for more details.
 
-### `fs.mkdtemp(prefix[, options], callback)`
+### `fs.mkdtemp(prefix, [options], callback)`
 
 <!-- YAML
 added: v5.10.0
@@ -3351,7 +3351,7 @@ mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
 });
 ```
 
-### `fs.open(path[, flags[, mode]], callback)`
+### `fs.open(path[flags, [mode]], callback)`
 
 <!-- YAML
 added: v0.0.2
@@ -3397,7 +3397,7 @@ a colon, Node.js will open a file system stream, as described by
 Functions based on `fs.open()` exhibit this behavior as well:
 `fs.writeFile()`, `fs.readFile()`, etc.
 
-### `fs.openAsBlob(path[, options])`
+### `fs.openAsBlob(path, [options])`
 
 <!-- YAML
 added: v19.8.0
@@ -3435,7 +3435,7 @@ const { openAsBlob } = require('node:fs');
 })();
 ```
 
-### `fs.opendir(path[, options], callback)`
+### `fs.opendir(path, [options], callback)`
 
 <!-- YAML
 added: v12.12.0
@@ -3523,7 +3523,7 @@ number of bytes read is zero.
 If this method is invoked as its [`util.promisify()`][]ed version, it returns
 a promise for an `Object` with `bytesRead` and `buffer` properties.
 
-### `fs.read(fd[, options], callback)`
+### `fs.read(fd, [options], callback)`
 
 <!-- YAML
 added:
@@ -3553,7 +3553,7 @@ Similar to the [`fs.read()`][] function, this version takes an optional
 `options` object. If no `options` object is specified, it will default with the
 above values.
 
-### `fs.read(fd, buffer[, options], callback)`
+### `fs.read(fd, buffer, [options], callback)`
 
 <!-- YAML
 added:
@@ -3577,7 +3577,7 @@ Similar to the [`fs.read()`][] function, this version takes an optional
 `options` object. If no `options` object is specified, it will default with the
 above values.
 
-### `fs.readdir(path[, options], callback)`
+### `fs.readdir(path, [options], callback)`
 
 <!-- YAML
 added: v0.1.8
@@ -3635,7 +3635,7 @@ the filenames returned will be passed as {Buffer} objects.
 If `options.withFileTypes` is set to `true`, the `files` array will contain
 {fs.Dirent} objects.
 
-### `fs.readFile(path[, options], callback)`
+### `fs.readFile(path, [options], callback)`
 
 <!-- YAML
 added: v0.1.29
@@ -3781,7 +3781,7 @@ The Node.js GitHub issue [#25741][] provides more information and a detailed
 analysis on the performance of `fs.readFile()` for multiple file sizes in
 different Node.js versions.
 
-### `fs.readlink(path[, options], callback)`
+### `fs.readlink(path, [options], callback)`
 
 <!-- YAML
 added: v0.1.31
@@ -3822,7 +3822,7 @@ object with an `encoding` property specifying the character encoding to use for
 the link path passed to the callback. If the `encoding` is set to `'buffer'`,
 the link path returned will be passed as a {Buffer} object.
 
-### `fs.readv(fd, buffers[, position], callback)`
+### `fs.readv(fd, buffers, [position], callback)`
 
 <!-- YAML
 added:
@@ -3857,7 +3857,7 @@ The callback will be given three arguments: `err`, `bytesRead`, and
 If this method is invoked as its [`util.promisify()`][]ed version, it returns
 a promise for an `Object` with `bytesRead` and `buffers` properties.
 
-### `fs.realpath(path[, options], callback)`
+### `fs.realpath(path, [options], callback)`
 
 <!-- YAML
 added: v0.1.31
@@ -3924,7 +3924,7 @@ the path returned will be passed as a {Buffer} object.
 If `path` resolves to a socket or a pipe, the function will return a system
 dependent name for that object.
 
-### `fs.realpath.native(path[, options], callback)`
+### `fs.realpath.native(path, [options], callback)`
 
 <!-- YAML
 added: v9.2.0
@@ -4005,7 +4005,7 @@ rename('oldFile.txt', 'newFile.txt', (err) => {
 });
 ```
 
-### `fs.rmdir(path[, options], callback)`
+### `fs.rmdir(path, [options], callback)`
 
 <!-- YAML
 added: v0.0.2
@@ -4084,7 +4084,7 @@ Windows and an `ENOTDIR` error on POSIX.
 To get a behavior similar to the `rm -rf` Unix command, use [`fs.rm()`][]
 with options `{ recursive: true, force: true }`.
 
-### `fs.rm(path[, options], callback)`
+### `fs.rm(path, [options], callback)`
 
 <!-- YAML
 added: v14.14.0
@@ -4118,7 +4118,7 @@ Asynchronously removes files and directories (modeled on the standard POSIX `rm`
 utility). No arguments other than a possible exception are given to the
 completion callback.
 
-### `fs.stat(path[, options], callback)`
+### `fs.stat(path, [options], callback)`
 
 <!-- YAML
 added: v0.0.2
@@ -4240,7 +4240,7 @@ Stats {
 }
 ```
 
-### `fs.statfs(path[, options], callback)`
+### `fs.statfs(path, [options], callback)`
 
 <!-- YAML
 added:
@@ -4262,7 +4262,7 @@ is an {fs.StatFs} object.
 
 In case of an error, the `err.code` will be one of [Common System Errors][].
 
-### `fs.symlink(target, path[, type], callback)`
+### `fs.symlink(target, path, [type], callback)`
 
 <!-- YAML
 added: v0.1.31
@@ -4320,7 +4320,7 @@ $ tree .
 └── mewtwo -> ./mew
 ```
 
-### `fs.truncate(path[, len], callback)`
+### `fs.truncate(path, [len], callback)`
 
 <!-- YAML
 added: v0.8.6
@@ -4421,7 +4421,7 @@ directory, use [`fs.rmdir()`][].
 
 See the POSIX unlink(2) documentation for more details.
 
-### `fs.unwatchFile(filename[, listener])`
+### `fs.unwatchFile(filename, [listener])`
 
 <!-- YAML
 added: v0.1.31
@@ -4489,7 +4489,7 @@ The `atime` and `mtime` arguments follow these rules:
 * If the value can not be converted to a number, or is `NaN`, `Infinity`, or
   `-Infinity`, an `Error` will be thrown.
 
-### `fs.watch(filename[, options][, listener])`
+### `fs.watch(filename, [options], [listener])`
 
 <!-- YAML
 added: v0.5.10
@@ -4617,7 +4617,7 @@ watch('somedir', (eventType, filename) => {
 });
 ```
 
-### `fs.watchFile(filename[, options], listener)`
+### `fs.watchFile(filename, [options], listener)`
 
 <!-- YAML
 added: v0.1.31
@@ -4688,7 +4688,7 @@ This happens when:
 * the file is deleted, followed by a restore
 * the file is renamed and then renamed a second time back to its original name
 
-### `fs.write(fd, buffer, offset[, length[, position]], callback)`
+### `fs.write(fd, buffer, offset, [length, [position]], callback)`
 
 <!-- YAML
 added: v0.0.2
@@ -4755,7 +4755,7 @@ On Linux, positional writes don't work when the file is opened in append mode.
 The kernel ignores the position argument and always appends the data to
 the end of the file.
 
-### `fs.write(fd, buffer[, options], callback)`
+### `fs.write(fd, buffer, [options], callback)`
 
 <!-- YAML
 added:
@@ -4780,7 +4780,7 @@ Similar to the above `fs.write` function, this version takes an
 optional `options` object. If no `options` object is specified, it will
 default with the above values.
 
-### `fs.write(fd, string[, position[, encoding]], callback)`
+### `fs.write(fd, string, [position, [encoding]], callback)`
 
 <!-- YAML
 added: v0.11.5
@@ -4852,7 +4852,7 @@ It is possible to configure the console to render UTF-8 properly by changing the
 active codepage with the `chcp 65001` command. See the [chcp][] docs for more
 details.
 
-### `fs.writeFile(file, data[, options], callback)`
+### `fs.writeFile(file, data, [options], callback)`
 
 <!-- YAML
 added: v0.1.29
@@ -5007,7 +5007,7 @@ on the size of the original file, and the position of the file descriptor). If
 a file name had been used instead of a descriptor, the file would be guaranteed
 to contain only `', World'`.
 
-### `fs.writev(fd, buffers[, position], callback)`
+### `fs.writev(fd, buffers, [position], callback)`
 
 <!-- YAML
 added: v12.9.0
@@ -5052,7 +5052,7 @@ the end of the file.
 The synchronous APIs perform all operations synchronously, blocking the
 event loop until the operation completes or fails.
 
-### `fs.accessSync(path[, mode])`
+### `fs.accessSync(path, [mode])`
 
 <!-- YAML
 added: v0.11.15
@@ -5088,7 +5088,7 @@ try {
 }
 ```
 
-### `fs.appendFileSync(path, data[, options])`
+### `fs.appendFileSync(path, data, [options])`
 
 <!-- YAML
 added: v0.6.7
@@ -5207,7 +5207,7 @@ through any other `fs` operation may lead to undefined behavior.
 
 See the POSIX close(2) documentation for more detail.
 
-### `fs.copyFileSync(src, dest[, mode])`
+### `fs.copyFileSync(src, dest, [mode])`
 
 <!-- YAML
 added: v8.5.0
@@ -5252,7 +5252,7 @@ console.log('source.txt was copied to destination.txt');
 copyFileSync('source.txt', 'destination.txt', constants.COPYFILE_EXCL);
 ```
 
-### `fs.cpSync(src, dest[, options])`
+### `fs.cpSync(src, dest, [options])`
 
 <!-- YAML
 added: v16.7.0
@@ -5372,7 +5372,7 @@ Forces all currently queued I/O operations associated with the file to the
 operating system's synchronized I/O completion state. Refer to the POSIX
 fdatasync(2) documentation for details. Returns `undefined`.
 
-### `fs.fstatSync(fd[, options])`
+### `fs.fstatSync(fd, [options])`
 
 <!-- YAML
 added: v0.1.95
@@ -5405,7 +5405,7 @@ Request that all data for the open file descriptor is flushed to the storage
 device. The specific implementation is operating system and device specific.
 Refer to the POSIX fsync(2) documentation for more detail. Returns `undefined`.
 
-### `fs.ftruncateSync(fd[, len])`
+### `fs.ftruncateSync(fd, [len])`
 
 <!-- YAML
 added: v0.8.6
@@ -5504,7 +5504,7 @@ changes:
 Creates a new link from the `existingPath` to the `newPath`. See the POSIX
 link(2) documentation for more detail. Returns `undefined`.
 
-### `fs.lstatSync(path[, options])`
+### `fs.lstatSync(path, [options])`
 
 <!-- YAML
 added: v0.1.30
@@ -5538,7 +5538,7 @@ Retrieves the {fs.Stats} for the symbolic link referred to by `path`.
 
 See the POSIX lstat(2) documentation for more details.
 
-### `fs.mkdirSync(path[, options])`
+### `fs.mkdirSync(path, [options])`
 
 <!-- YAML
 added: v0.1.21
@@ -5570,7 +5570,7 @@ This is the synchronous version of [`fs.mkdir()`][].
 
 See the POSIX mkdir(2) documentation for more details.
 
-### `fs.mkdtempSync(prefix[, options])`
+### `fs.mkdtempSync(prefix, [options])`
 
 <!-- YAML
 added: v5.10.0
@@ -5598,7 +5598,7 @@ this API: [`fs.mkdtemp()`][].
 The optional `options` argument can be a string specifying an encoding, or an
 object with an `encoding` property specifying the character encoding to use.
 
-### `fs.opendirSync(path[, options])`
+### `fs.opendirSync(path, [options])`
 
 <!-- YAML
 added: v12.12.0
@@ -5632,7 +5632,7 @@ and cleaning up the directory.
 The `encoding` option sets the encoding for the `path` while opening the
 directory and subsequent read operations.
 
-### `fs.openSync(path[, flags[, mode]])`
+### `fs.openSync(path, [flags, [mode]])`
 
 <!-- YAML
 added: v0.1.21
@@ -5660,7 +5660,7 @@ Returns an integer representing the file descriptor.
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.open()`][].
 
-### `fs.readdirSync(path[, options])`
+### `fs.readdirSync(path, [options])`
 
 <!-- YAML
 added: v0.1.21
@@ -5698,7 +5698,7 @@ the filenames returned will be passed as {Buffer} objects.
 If `options.withFileTypes` is set to `true`, the result will contain
 {fs.Dirent} objects.
 
-### `fs.readFileSync(path[, options])`
+### `fs.readFileSync(path, [options])`
 
 <!-- YAML
 added: v0.1.8
@@ -5740,7 +5740,7 @@ readFileSync('<directory>');
 readFileSync('<directory>'); // => <data>
 ```
 
-### `fs.readlinkSync(path[, options])`
+### `fs.readlinkSync(path, [options])`
 
 <!-- YAML
 added: v0.1.31
@@ -5765,7 +5765,7 @@ object with an `encoding` property specifying the character encoding to use for
 the link path returned. If the `encoding` is set to `'buffer'`,
 the link path returned will be passed as a {Buffer} object.
 
-### `fs.readSync(fd, buffer, offset, length[, position])`
+### `fs.readSync(fd, buffer, offset, length, [position])`
 
 <!-- YAML
 added: v0.1.21
@@ -5791,7 +5791,7 @@ Returns the number of `bytesRead`.
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.read()`][].
 
-### `fs.readSync(fd, buffer[, options])`
+### `fs.readSync(fd, buffer, [options])`
 
 <!-- YAML
 added:
@@ -5822,7 +5822,7 @@ If no `options` object is specified, it will default with the above values.
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.read()`][].
 
-### `fs.readvSync(fd, buffers[, position])`
+### `fs.readvSync(fd, buffers, [position])`
 
 <!-- YAML
 added:
@@ -5838,7 +5838,7 @@ added:
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.readv()`][].
 
-### `fs.realpathSync(path[, options])`
+### `fs.realpathSync(path, [options])`
 
 <!-- YAML
 added: v0.1.31
@@ -5869,7 +5869,7 @@ Returns the resolved pathname.
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.realpath()`][].
 
-### `fs.realpathSync.native(path[, options])`
+### `fs.realpathSync.native(path, [options])`
 
 <!-- YAML
 added: v9.2.0
@@ -5912,7 +5912,7 @@ Renames the file from `oldPath` to `newPath`. Returns `undefined`.
 
 See the POSIX rename(2) documentation for more details.
 
-### `fs.rmdirSync(path[, options])`
+### `fs.rmdirSync(path, [options])`
 
 <!-- YAML
 added: v0.1.21
@@ -5975,7 +5975,7 @@ on Windows and an `ENOTDIR` error on POSIX.
 To get a behavior similar to the `rm -rf` Unix command, use [`fs.rmSync()`][]
 with options `{ recursive: true, force: true }`.
 
-### `fs.rmSync(path[, options])`
+### `fs.rmSync(path, [options])`
 
 <!-- YAML
 added: v14.14.0
@@ -6006,7 +6006,7 @@ changes:
 Synchronously removes files and directories (modeled on the standard POSIX `rm`
 utility). Returns `undefined`.
 
-### `fs.statSync(path[, options])`
+### `fs.statSync(path, [options])`
 
 <!-- YAML
 added: v0.1.21
@@ -6038,7 +6038,7 @@ changes:
 
 Retrieves the {fs.Stats} for the path.
 
-### `fs.statfsSync(path[, options])`
+### `fs.statfsSync(path, [options])`
 
 <!-- YAML
 added:
@@ -6057,7 +6057,7 @@ contains `path`.
 
 In case of an error, the `err.code` will be one of [Common System Errors][].
 
-### `fs.symlinkSync(target, path[, type])`
+### `fs.symlinkSync(target, path, [type])`
 
 <!-- YAML
 added: v0.1.31
@@ -6082,7 +6082,7 @@ Returns `undefined`.
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.symlink()`][].
 
-### `fs.truncateSync(path[, len])`
+### `fs.truncateSync(path, [len])`
 
 <!-- YAML
 added: v0.8.6
@@ -6140,7 +6140,7 @@ Returns `undefined`.
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.utimes()`][].
 
-### `fs.writeFileSync(file, data[, options])`
+### `fs.writeFileSync(file, data, [options])`
 
 <!-- YAML
 added: v0.1.29
@@ -6188,7 +6188,7 @@ for more details.
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.writeFile()`][].
 
-### `fs.writeSync(fd, buffer, offset[, length[, position]])`
+### `fs.writeSync(fd, buffer, offset, [length, [position]])`
 
 <!-- YAML
 added: v0.1.21
@@ -6219,7 +6219,7 @@ changes:
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.write(fd, buffer...)`][].
 
-### `fs.writeSync(fd, buffer[, options])`
+### `fs.writeSync(fd, buffer, [options])`
 
 <!-- YAML
 added:
@@ -6238,7 +6238,7 @@ added:
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.write(fd, buffer...)`][].
 
-### `fs.writeSync(fd, string[, position[, encoding]])`
+### `fs.writeSync(fd, string, [position, [encoding]])`
 
 <!-- YAML
 added: v0.11.5
@@ -6261,7 +6261,7 @@ changes:
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.write(fd, string...)`][].
 
-### `fs.writevSync(fd, buffers[, position])`
+### `fs.writevSync(fd, buffers, [position])`
 
 <!-- YAML
 added: v12.9.0


### PR DESCRIPTION
Fixed comma( , ) placement error which was present in many lines in the "File System (fs.md)" doc. For Example :

fs.access(path[, mode], callback)   -->   fs.access(path, [mode], callback)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
